### PR TITLE
FIX: Certificate Pinning Compilation on Linux

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -40,6 +40,10 @@ Chris O'Gorman (chogorma)
 Ocedo GmbH
 Henning Pfeiffer (megaposer)
 
+neXenio GmbH
+Patrik Fiedler (xqp)
+René Meusel (reneme)
+
 thomasschaub
 
 Trimble

--- a/Release/include/cpprest/details/x509_cert_utilities.h
+++ b/Release/include/cpprest/details/x509_cert_utilities.h
@@ -16,7 +16,7 @@
 #include <string>
 #include "cpprest/certificate_info.h"
 
-#if defined(__APPLE__) || (defined(ANDROID) || defined(__ANDROID__)) || (defined(_WIN32)  && !defined(__cplusplus_winrt) && !defined(_M_ARM) && !defined(CPPREST_EXCLUDE_WEBSOCKETS))
+#if defined(__linux__) || defined(__APPLE__) || (defined(ANDROID) || defined(__ANDROID__)) || (defined(_WIN32)  && !defined(__cplusplus_winrt) && !defined(_M_ARM) && !defined(CPPREST_EXCLUDE_WEBSOCKETS))
 
 #if defined(_MSC_VER)
 #pragma warning(push)
@@ -38,6 +38,7 @@ namespace web { namespace http { namespace client { namespace details {
 
 using namespace utility;
 
+#if !defined(__linux__)
 
 bool is_end_certificate_in_chain(boost::asio::ssl::verify_context &verifyCtx);
 
@@ -49,8 +50,10 @@ bool is_end_certificate_in_chain(boost::asio::ssl::verify_context &verifyCtx);
 /// <param name="hostName">Host name from the URI.</param>
 /// <returns>True if verification passed and server can be trusted, false otherwise.</returns>
 bool verify_cert_chain_platform_specific(boost::asio::ssl::verify_context &verifyCtx, const std::string &hostName, const CertificateChainFunction& func = nullptr);
-
 bool verify_X509_cert_chain(const std::vector<std::string> &certChain, const std::string &hostName, const CertificateChainFunction& func = nullptr);
+
+#endif
+
 
 std::vector<std::vector<unsigned char>> get_X509_cert_chain_encoded_data(boost::asio::ssl::verify_context &verifyCtx);
 

--- a/Release/src/http/client/x509_cert_utilities.cpp
+++ b/Release/src/http/client/x509_cert_utilities.cpp
@@ -13,7 +13,7 @@
 
 #include "stdafx.h"
 
-#if defined(__APPLE__) || (defined(ANDROID) || defined(__ANDROID__)) || (defined(_WIN32)  && !defined(__cplusplus_winrt) && !defined(_M_ARM) && !defined(CPPREST_EXCLUDE_WEBSOCKETS))
+#if defined(__linux__) || defined(__APPLE__) || (defined(ANDROID) || defined(__ANDROID__)) || (defined(_WIN32)  && !defined(__cplusplus_winrt) && !defined(_M_ARM) && !defined(CPPREST_EXCLUDE_WEBSOCKETS))
 
 #include "cpprest/details/x509_cert_utilities.h"
 #include <vector>
@@ -39,6 +39,8 @@
 #include <iomanip>
 
 namespace web { namespace http { namespace client { namespace details {
+
+#if !defined(__linux__)
 
 bool is_end_certificate_in_chain(boost::asio::ssl::verify_context &verifyCtx)
 {
@@ -103,6 +105,8 @@ bool verify_cert_chain_platform_specific(boost::asio::ssl::verify_context &verif
 #endif
     return verify_result;
 }
+
+#endif
 
 #if defined(ANDROID) || defined(__ANDROID__)
 using namespace crossplat;


### PR DESCRIPTION
This enables your currently open [upstream Pull Request](https://github.com/Microsoft/cpprestsdk/pull/702) to successfully compile (and work) on Linux. Currently the `CertificateChainFunction`-callback is invoked several times for each connection on Linux. I suppose this is due to the way OpenSSL handles the certificate chain element-by-element.