### PR TITLE
linux: invoke the certificate chain callback only once

### DIFF
--- a/Release/include/cpprest/certificate_info.h
+++ b/Release/include/cpprest/certificate_info.h
@@ -34,13 +34,13 @@ namespace web { namespace http { namespace client {
 
     struct certificate_info
     {
-        CertificateChain certificate_chain;
         std::string host_name;
+        CertificateChain certificate_chain;
         long certificate_error{ 0 };
         bool verified{ false };
 
-        certificate_info(const std::string host) : host_name(host) {};
-        certificate_info(const std::string host, CertificateChain chain, long error = 0) : host_name(host), certificate_chain(chain), certificate_error(error) {};
+        certificate_info(const std::string host) : host_name(host) {}
+        certificate_info(const std::string host, CertificateChain chain, long error = 0) : host_name(host), certificate_chain(chain), certificate_error(error) {}
     };
 
     using CertificateChainFunction = std::function<bool(const std::shared_ptr<certificate_info> certificate_Info)>;

--- a/Release/include/cpprest/details/x509_cert_utilities.h
+++ b/Release/include/cpprest/details/x509_cert_utilities.h
@@ -38,10 +38,9 @@ namespace web { namespace http { namespace client { namespace details {
 
 using namespace utility;
 
-#if !defined(__linux__)
-
 bool is_end_certificate_in_chain(boost::asio::ssl::verify_context &verifyCtx);
 
+#if !defined(__linux__)
 /// <summary>
 /// Using platform specific APIs verifies server certificate.
 /// Currently implemented to work on iOS, Android, and OS X.

--- a/Release/include/cpprest/ws_client.h
+++ b/Release/include/cpprest/ws_client.h
@@ -226,13 +226,13 @@ public:
     }
 
 private:
+    http::client::CertificateChainFunction m_certificate_chain_callback;
     web::web_proxy m_proxy;
     web::credentials m_credentials;
     web::http::http_headers m_headers;
     bool m_sni_enabled;
     utf8string m_sni_hostname;
     bool m_validate_certificates;
-    http::client::CertificateChainFunction m_certificate_chain_callback;
 };
 
 /// <summary>

--- a/Release/src/http/client/http_client_asio.cpp
+++ b/Release/src/http/client/http_client_asio.cpp
@@ -444,7 +444,7 @@ public:
     , m_needChunked(false)
     , m_timer(client->client_config().timeout<std::chrono::microseconds>())
     , m_connection(connection)
-#if defined(__APPLE__) || (defined(ANDROID) || defined(__ANDROID__))
+#if defined(__APPLE__) || defined(ANDROID) || defined(__ANDROID__)
     , m_openssl_failed(false)
 #endif
     {}
@@ -980,7 +980,7 @@ private:
 
         using namespace web::http::client::details;
 
-#if defined(__APPLE__) || (defined(ANDROID) || defined(__ANDROID__))
+#if defined(__APPLE__) || defined(ANDROID) || defined(__ANDROID__)
         // On OS X, iOS, and Android, OpenSSL doesn't have access to where the OS
         // stores keychains. If OpenSSL fails we will doing verification at the
         // end using the whole certificate chain so wait until the 'leaf' cert.
@@ -1003,7 +1003,7 @@ private:
             };
 
             return http::client::details::verify_cert_chain_platform_specific(verifyCtx, utility::conversions::to_utf8string(host), chainFunc);
-            }
+        }
 #endif
 
         boost::asio::ssl::rfc2818_verification rfc2818(host);
@@ -1014,6 +1014,12 @@ private:
 
         auto info = std::make_shared<certificate_info>(host, get_X509_cert_chain_encoded_data(verifyCtx));
         info->verified = true;
+
+        if (!is_end_certificate_in_chain(verifyCtx))
+        {
+            // Continue until we get the end certificate.
+            return true;
+        }
 
         return m_http_client->client_config().invoke_certificate_chain_callback(info);
     }
@@ -1687,7 +1693,7 @@ private:
     
     std::unique_ptr<web::http::details::compression::stream_decompressor> m_decompressor;
 
-#if defined(__APPLE__) || (defined(ANDROID) || defined(__ANDROID__))
+#if defined(__APPLE__) || defined(ANDROID) || defined(__ANDROID__)
     bool m_openssl_failed;
 #endif
 };

--- a/Release/src/http/client/x509_cert_utilities.cpp
+++ b/Release/src/http/client/x509_cert_utilities.cpp
@@ -40,8 +40,6 @@
 
 namespace web { namespace http { namespace client { namespace details {
 
-#if !defined(__linux__)
-
 bool is_end_certificate_in_chain(boost::asio::ssl::verify_context &verifyCtx)
 {
     X509_STORE_CTX *storeContext = verifyCtx.native_handle();
@@ -52,6 +50,8 @@ bool is_end_certificate_in_chain(boost::asio::ssl::verify_context &verifyCtx)
     }
         return true;
 }
+
+#if !defined(__linux__)
 
 bool verify_cert_chain_platform_specific(boost::asio::ssl::verify_context &verifyCtx, const std::string &hostName, const CertificateChainFunction& func)
 {


### PR DESCRIPTION
Hey chogormac,

this pr includes
- skips the callback call if the certificate is not the end certificate (like macos and windows)
- fix warnings regarding the initialization from class member